### PR TITLE
Use GitHub as a source of plugin documentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <name>GitHub Status Wrapper Plugin</name>
     <description>Plugin that provides wrappers for github statuses</description>
 
-    <url>https://wiki.jenkins.io/display/JENKINS/GitStatusWrapper+Plugin</url>
+    <url>https://github.com/jenkinsci/pipeline-gitstatuswrapper-plugin</url>
 
     <developers>
         <developer>


### PR DESCRIPTION
Now it is possible to use GitHub documentation directly instead of duplicating it in Wiki. See https://jenkins.io/blog/2019/10/21/plugin-docs-on-github/